### PR TITLE
Fix german translation

### DIFF
--- a/config/locales/gettext/de/app.po
+++ b/config/locales/gettext/de/app.po
@@ -2543,8 +2543,8 @@ msgid ""
 "Please obtain and securely store this content in a secure manner, such as in a"
 " password manager."
 msgstr ""
-"Bitte dieses Passwort sicher an anderer, sicherer Stelle aufbewahren. Wir empf"
-"ehlen einen Passwort-Manager."
+"Bitte bewahren Sie das Passwort nach dem Kopieren an einem sicheren Ort auf. Wir empf"
+"ehlen dafür einen Passwort-Manager zu verwenden."
 
 #: ../../../app/views/passwords/show.html.erb:9
 msgid "Your password is blurred out.  Click below to reveal it."


### PR DESCRIPTION
## Description

There is a minor grammar issue in the german translation on the page where the password can be obtained.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

no code changes
